### PR TITLE
Use any 3.6 version of Python

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,14 +5,14 @@ package:
 requirements:
   build:
     - python=3.6
-    - "numpy>=1.12.1"
-    - "pandas>=0.22.0"
+    - numpy=1.13
+    - pandas=0.23
     - taxcalc
 
   run:
     - python=3.6
-    - "numpy>=1.12.1"
-    - "pandas>=0.22.0"
+    - numpy=1.13
+    - pandas=0.23
     - taxcalc
 
 test:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,16 +4,16 @@ package:
 
 requirements:
   build:
-    - python >=3.6.5,<3.7
-    - numpy >=1.12.1
-    - pandas >=0.22.0
-    - taxcalc >=0.22.1
+    - python=3.6
+    - numpy>=1.12.1
+    - pandas>=0.22.0
+    - taxcalc>=0.22.1
 
   run:
-    - python >=3.6.5,<3.7
-    - numpy >=1.12.1
-    - pandas >=0.22.0
-    - taxcalc >=0.22.1
+    - python=3.6
+    - numpy>=1.12.1
+    - pandas>=0.22.0
+    - taxcalc>=0.22.1
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,15 +5,15 @@ package:
 requirements:
   build:
     - python=3.6
-    - numpy>=1.12.1
-    - pandas>=0.22.0
-    - taxcalc>=0.22.1
+    - "numpy>=1.12.1"
+    - "pandas>=0.22.0"
+    - taxcalc
 
   run:
     - python=3.6
-    - numpy>=1.12.1
-    - pandas>=0.22.0
-    - taxcalc>=0.22.1
+    - "numpy>=1.12.1"
+    - "pandas>=0.22.0"
+    - taxcalc
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ channels:
 - ospc
 dependencies:
 - python=3.6
-- "numpy>=1.12.1"
-- "pandas>=0.22.0"
+- numpy=1.13
+- pandas=0.23
 - taxcalc
 - pytest
 - pytest-pep8

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
 - ospc
 dependencies:
 - python=3.6
-- numpy>=1.12.1
-- pandas>=0.22.0
-- taxcalc>=0.22.1
+- "numpy>=1.12.1"
+- "pandas>=0.22.0"
+- taxcalc
 - pytest
 - pytest-pep8
 - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: behresp-dev
 channels:
 - ospc
 dependencies:
-- python >=3.6.5,<3.7
-- numpy >=1.12.1
-- pandas >=0.22.0
-- taxcalc >=0.22.1
+- python=3.6
+- numpy>=1.12.1
+- pandas>=0.22.0
+- taxcalc>=0.22.1
 - pytest
 - pytest-pep8
 - pytest-xdist


### PR DESCRIPTION
This pull request changes the representation of package version restrictions in the `environment.yml` and `conda.recipe/meta.yaml` files to make them more like what is shown in the [conda cheat sheet](https://conda.io/docs/_downloads/conda-cheatsheet.pdf).