### PR TITLE
Simplify package dependencies

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,26 @@ Go [here](https://github.com/open-source-economics/Behavioral-Responses/pulls?q=
 for a complete commit history.
 
 
+2018-11-06 Release 0.3.0
+------------------------
+(last merged pull request is
+[#18](https://github.com/open-source-economics/Behavioral-Responses/pull/18))
+
+**API Changes**
+- Simplify specification of package dependencies
+  [[#18](https://github.com/open-source-economics/Behavioral-Responses/pull/18)
+  by Martin Holmer]
+
+**New Features**
+- None
+
+**Bug Fixes**
+- None
+
+
+_Earlier Releases:_
+
+
 2018-11-03 Release 0.2.0
 ------------------------
 (last merged pull request is
@@ -19,9 +39,6 @@ for a complete commit history.
 
 **Bug Fixes**
 - None
-
-
-_Earlier Releases:_
 
 
 2018-11-01 Release 0.1.0

--- a/behresp/tests/test_4package.py
+++ b/behresp/tests/test_4package.py
@@ -30,15 +30,6 @@ def test_for_consistency(tests_path):
     Ensure that there is consistency between environment.yml dependencies
     and conda.recipe/meta.yaml requirements.
     """
-    dev_pkgs = set([
-        'pytest',
-        'pytest-pep8',
-        'pytest-xdist',
-        'pyyaml',
-        'pycodestyle',
-        'pylint',
-        'coverage'
-    ])
     # read conda.recipe/meta.yaml requirements
     meta_file = os.path.join(tests_path, '..', '..',
                              'conda.recipe', 'meta.yaml')
@@ -54,6 +45,5 @@ def test_for_consistency(tests_path):
     with open(envr_file, 'r') as stream:
         envr = yaml.load(stream)
     env = set(envr['dependencies'])
-    # confirm that extras in env (relative to run) equal the dev_pkgs set
-    extras = env - run
-    assert extras == dev_pkgs
+    # confirm that environment and run packages are the same
+    assert env == run

--- a/conda.recipe/install_local_package.sh
+++ b/conda.recipe/install_local_package.sh
@@ -16,7 +16,7 @@ echo "BUILD-PREP..."
 
 # check version of conda package
 conda list conda | awk '$1=="conda"{v=$2;gsub(/\./,"",v);nv=v+0;if(nv<444)rc=1}END{exit(rc)}'
-if [ $? -eq 1 ]; then
+if [[ $? -eq 1 ]]; then
     echo "==> Installing conda 4.4.4+"
     conda install conda>=4.4.4 --yes 2>&1 > /dev/null
     echo "==> Continuing to build new behresp package"
@@ -24,16 +24,15 @@ fi
 
 # install conda-build package if not present
 conda list build | awk '$1~/conda-build/{rc=1}END{exit(rc)}'
-if [ $? -eq 0 ]; then
+if [[ $? -eq 0 ]]; then
     echo "==> Installing conda-build package"
     conda install conda-build --yes 2>&1 > /dev/null
     echo "==> Continuing to build new behresp package"
 fi
 
 # build behresp conda package for this version of Python
-NOHASH=--old-build-string
-pversion=3.6
-conda build $NOHASH --python $pversion . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
+OPTIONS="--old-build-string --python 3.6"
+conda build $OPTIONS . 2>&1 | awk '$1~/BUILD/||$1~/TEST/'
 
 # install behresp conda package
 echo "INSTALLATION..."
@@ -42,6 +41,8 @@ conda install behresp=0.0.0 --use-local --yes 2>&1 > /dev/null
 # NOTE: see https://github.com/conda/conda/issues/6520
 # NOTE: interim usage was as follows:
 # NOTE: conda install -c local behresp=0.0.0 --yes 2>&1 > /dev/null
+
+exit 0
 
 # clean-up after package build
 echo "CLEAN-UP..."

--- a/conda.recipe/install_local_package.sh
+++ b/conda.recipe/install_local_package.sh
@@ -42,8 +42,6 @@ conda install behresp=0.0.0 --use-local --yes 2>&1 > /dev/null
 # NOTE: interim usage was as follows:
 # NOTE: conda install -c local behresp=0.0.0 --yes 2>&1 > /dev/null
 
-exit 0
-
 # clean-up after package build
 echo "CLEAN-UP..."
 conda build purge 2> /dev/null

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,14 +5,10 @@ package:
 requirements:
   build:
     - python=3.6
-    - "numpy>=1.13"
-    - "pandas>=0.22"
     - taxcalc
 
   run:
     - python=3.6
-    - "numpy>=1.13"
-    - "pandas>=0.22"
     - taxcalc
 
 test:

--- a/conda.recipe/remove_local_package.sh
+++ b/conda.recipe/remove_local_package.sh
@@ -6,7 +6,7 @@
 
 # uninstall any existing behresp conda package
 conda list behresp | awk '$1~/behresp/{rc=1}END{exit(rc)}'
-if [ $? -eq 1 ]; then
+if [[ $? -eq 1 ]]; then
     conda uninstall behresp --yes 2>&1 > /dev/null
 fi
 

--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -20,6 +20,7 @@ conda create -n %CONDA_ENV% -q -y python=%PYTHON%
 call activate %CONDA_ENV%
 
 %CONDA% env update -f environment.yml
+%CONDA_INSTALL% pytest
 
 @rem Display final environment (for reproducing)
 %CONDA% list

--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,6 @@
 name: behresp-dev
 channels:
-- ospc
+- OSPC
 dependencies:
 - python=3.6
-- "numpy>=1.13"
-- "pandas>=0.22"
 - taxcalc
-- pytest
-- pytest-pep8
-- pytest-xdist
-- pyyaml
-- pycodestyle
-- pylint
-- coverage


### PR DESCRIPTION
This pull request attempts to simplify the package dependencies contained in the `environment.yml` and `conda.recipe/meta.yaml` files.  This simplification is made possible by the fact that the Behavioral-Responses behresp package does not depend on any packages other than those the Tax-Calculator taxcalc package depends on.  This simplification works on my local computer and this pull request will see if it works on GitHub when the checkin tests are run.

The Travis tests on Linux ran successfully from the initial commit.  However, the AppVeyor (continuous_integration) tests  on Windows failed because, for some reason, it didn't have `pytest` installed.  Commit 57086c2 fixed that problem and now the tests also run successfully under AppVeyor on Windows.

This demonstrates the ability to **dramatically simplify** the package dependencies of **any** PSL model that depends on the Tax-Calculator `taxcalc` package.  Here is the `environment.yml` file checked-in as part of this Behavioral-Responses pull request:
```
name: behresp-dev
channels:
- OSPC
dependencies:
- python=3.6
- taxcalc
```
And here is the `conda.recipe/meta.yaml` file checked-in as part of this Behavioral-Responses pull request:
```
package:
  name: behresp
  version: 0.0.0

requirements:
  build:
    - python=3.6
    - taxcalc

  run:
    - python=3.6
    - taxcalc

test:
  imports:
    - behresp

about:
  home: https://github.com/open-source-economics/Behavioral-Response
```

Of course, if a PSL package depends on some package not used by Tax-Calculator, then that package would need to be added below the `- taxcalc` entries.

@MattHJensen @codykallen @jdebacker @rickecon @hdoupe @andersonfrailey 