### PR TITLE
Change ospc to PSLmodels

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,14 +73,14 @@ the <kbd>behresp</kbd> package (to access Behavioral-Responses).  Both
 these conda packages can be installed on your computer using this
 command at the operating-system command prompt:
 <pre>
-  conda install -c ospc behresp
+  conda install -c PSLmodels behresp
 </pre>
 Or, if you already have both of the packages installed but want to
 upgrade them to the most recent versions, use these commands at the
 operating-system command prompt:
 <pre>
-  conda update -c ospc taxcalc
-  conda update -c ospc behresp
+  conda update -c PSLmodels taxcalc
+  conda update -c PSLmodels behresp
 </pre>
 </p>
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: behresp-dev
 channels:
-- OSPC
+- PSLmodels
 dependencies:
 - python=3.6
 - taxcalc


### PR DESCRIPTION
This pull request contains only changes in documentation. The main point is to notify users and developers that `behresp` packages for Behavioral-Response release 0.3.0 and higher are available **only** on the Anaconda Cloud `PSLmodels` channel. So, instead of the old `conda install --c ospc behresp` command, you must use the new `conda install -c PSLmodels behresp` command. If you already have the `behresp` package installed, then substitute `update` for `install`.

@MattHJensen @codykallen @andersonfrailey @hdoupe @Amy-Xu @donboyd5 @evtedeschi3 @MaxGhenis